### PR TITLE
Add feature to expand single children and fix end bracket indent

### DIFF
--- a/app/src/main/java/com/sebastianneubauer/jsontreedemo/JsonStrings.kt
+++ b/app/src/main/java/com/sebastianneubauer/jsontreedemo/JsonStrings.kt
@@ -2111,8 +2111,12 @@ internal val complexJson = """
 internal val simpleJson = """
     {
     	"object": {
-            "longString": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
-    	}
+            "array": [
+                "value",
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+            ]
+    	},
+        "string": "Lorem ipsum"
     }
 """.trimIndent()
 

--- a/app/src/main/java/com/sebastianneubauer/jsontreedemo/MainActivity.kt
+++ b/app/src/main/java/com/sebastianneubauer/jsontreedemo/MainActivity.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -42,7 +44,7 @@ import java.lang.IllegalStateException
 
 internal class MainActivity : ComponentActivity() {
 
-    @OptIn(ExperimentalFoundationApi::class)
+    @OptIn(ExperimentalFoundationApi::class, ExperimentalLayoutApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -57,6 +59,7 @@ internal class MainActivity : ComponentActivity() {
                     var initialState: TreeState by remember { mutableStateOf(TreeState.FIRST_ITEM_EXPANDED) }
                     var showIndices: Boolean by remember { mutableStateOf(true) }
                     var showItemCount: Boolean by remember { mutableStateOf(true) }
+                    var expandSingleChildren: Boolean by remember { mutableStateOf(true) }
 
                     Spacer(modifier = Modifier.height(16.dp))
 
@@ -69,8 +72,9 @@ internal class MainActivity : ComponentActivity() {
 
                     Spacer(modifier = Modifier.height(48.dp))
 
-                    Row(modifier = Modifier.padding(horizontal = 16.dp)) {
+                    FlowRow {
                         Button(
+                            modifier = Modifier.padding(horizontal = 8.dp),
                             onClick = {
                                 errorMessage = null
                                 json = when (json) {
@@ -93,9 +97,8 @@ internal class MainActivity : ComponentActivity() {
                             )
                         }
 
-                        Spacer(modifier = Modifier.width(16.dp))
-
                         Button(
+                            modifier = Modifier.padding(horizontal = 8.dp),
                             onClick = {
                                 val newState = when(initialState) {
                                     TreeState.EXPANDED -> TreeState.COLLAPSED
@@ -107,30 +110,35 @@ internal class MainActivity : ComponentActivity() {
                         ) {
                             Text(text = initialState.name)
                         }
-                    }
 
-                    Button(
-                        modifier = Modifier.padding(horizontal = 16.dp),
-                        onClick = { showIndices = !showIndices }
-                    ) {
-                        Text(text = if(showIndices) "Hide indices" else "Show indices")
-                    }
-
-                    Row(modifier = Modifier.padding(horizontal = 16.dp)) {
                         Button(
+                            modifier = Modifier.padding(horizontal = 8.dp),
+                            onClick = { showIndices = !showIndices }
+                        ) {
+                            Text(text = if(showIndices) "Hide indices" else "Show indices")
+                        }
+
+                        Button(
+                            modifier = Modifier.padding(horizontal = 8.dp),
                             onClick = { showItemCount = !showItemCount }
                         ) {
                             Text(text = if(showItemCount) "Hide item count" else "Show item count")
                         }
 
-                        Spacer(modifier = Modifier.width(16.dp))
-
                         Button(
+                            modifier = Modifier.padding(horizontal = 8.dp),
                             onClick = {
                                 colors = if(colors == defaultLightColors) defaultDarkColors else defaultLightColors
                             }
                         ) {
                             Text(text = if(colors == defaultLightColors) "Light" else "Dark")
+                        }
+
+                        Button(
+                            modifier = Modifier.padding(horizontal = 8.dp),
+                            onClick = { expandSingleChildren = !expandSingleChildren }
+                        ) {
+                            Text(text = if(expandSingleChildren) "Expand children" else "Don't expand children")
                         }
                     }
 
@@ -180,6 +188,7 @@ internal class MainActivity : ComponentActivity() {
                                         colors = colors,
                                         showIndices = showIndices,
                                         showItemCount = showItemCount,
+                                        expandSingleChildren = expandSingleChildren,
                                         onError = { errorMessage = it.localizedMessage },
                                     )
                                 }

--- a/detekt/config.yml
+++ b/detekt/config.yml
@@ -16,6 +16,8 @@ complexity:
     functionThreshold: 15
   CyclomaticComplexMethod:
     threshold: 20
+  LargeClass:
+    threshold: 1000
 
 style:
   MagicNumber:

--- a/jsontree/api/jsontree.api
+++ b/jsontree/api/jsontree.api
@@ -1,5 +1,5 @@
 public final class com/sebastianneubauer/jsontree/JsonTreeKt {
-	public static final fun JsonTree-k3FuEkE (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/Modifier;Lcom/sebastianneubauer/jsontree/TreeState;Landroidx/compose/foundation/layout/PaddingValues;Lcom/sebastianneubauer/jsontree/TreeColors;Landroidx/compose/ui/graphics/vector/ImageVector;FLandroidx/compose/ui/text/TextStyle;ZZLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;III)V
+	public static final fun JsonTree-xKBSf-U (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/Modifier;Lcom/sebastianneubauer/jsontree/TreeState;Landroidx/compose/foundation/layout/PaddingValues;Lcom/sebastianneubauer/jsontree/TreeColors;Landroidx/compose/ui/graphics/vector/ImageVector;FLandroidx/compose/ui/text/TextStyle;ZZZLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;III)V
 }
 
 public final class com/sebastianneubauer/jsontree/TreeColors {

--- a/jsontree/src/androidTest/java/com/sebastianneubauer/jsontree/JsonTreeTest.kt
+++ b/jsontree/src/androidTest/java/com/sebastianneubauer/jsontree/JsonTreeTest.kt
@@ -404,4 +404,52 @@ internal class JsonTreeTest {
 
         composeTestRule.onNodeWithText("[ 1 item ]").assertIsDisplayed()
     }
+
+    @Test
+    fun expanding_single_children_is_handled_correctly() {
+        composeTestRule.setContent {
+            JsonTree(
+                json = arrayOfArraysJson,
+                initialState = TreeState.COLLAPSED,
+                onLoading = {},
+                expandSingleChildren = true
+            )
+        }
+
+        composeTestRule.onNodeWithText("{ 1 item }").performClick()
+        // shows nested array
+        composeTestRule.onNodeWithText("\"array\": [").assertIsDisplayed()
+        // shows collapsed contents of nested array
+        composeTestRule.onNodeWithText("[ 1 item ],").assertIsDisplayed()
+        composeTestRule.onNodeWithText("[ 2 items ]").assertIsDisplayed()
+
+        // collapse root
+        composeTestRule.onNodeWithText("{").performClick()
+        composeTestRule.onNodeWithText("{ 1 item }").assertIsDisplayed()
+    }
+
+    @Test
+    fun not_expanding_single_children_is_handled_correctly() {
+        composeTestRule.setContent {
+            JsonTree(
+                json = arrayOfArraysJson,
+                initialState = TreeState.COLLAPSED,
+                onLoading = {},
+                expandSingleChildren = false
+            )
+        }
+
+        composeTestRule.onNodeWithText("{ 1 item }").performClick()
+
+        composeTestRule.waitUntilExactlyOneExists(hasText("\"array\": [ 2 items ]"))
+        composeTestRule.onNodeWithText("\"array\": [ 2 items ]").assertIsDisplayed()
+        composeTestRule.onNodeWithText("\"array\": [ 2 items ]").performClick()
+
+        composeTestRule.onNodeWithText("[ 1 item ],").assertIsDisplayed()
+        composeTestRule.onNodeWithText("[ 2 items ]").assertIsDisplayed()
+
+        // collapse root
+        composeTestRule.onNodeWithText("{").performClick()
+        composeTestRule.onNodeWithText("{ 1 item }").assertIsDisplayed()
+    }
 }

--- a/jsontree/src/main/java/com/sebastianneubauer/jsontree/JsonTree.kt
+++ b/jsontree/src/main/java/com/sebastianneubauer/jsontree/JsonTree.kt
@@ -45,6 +45,9 @@ import kotlinx.coroutines.launch
  * @param iconSize The size of the [icon]. This size is also used to calculate indents.
  * @param textStyle The style which is used for all texts in the tree.
  * @param showIndices If true, arrays will show the index in front of each item.
+ * @param showItemCount If true, arrays and objects will show their amount of child items when collapsed.
+ * @param expandSingleChildren If true, children of collapsable items that have no siblings will be
+ * automatically expanded with their parent.
  * @param onError A callback which is called when the json can't be parsed and thus won't
  * be rendered. Receives the throwable of the error.
  */
@@ -61,6 +64,7 @@ public fun JsonTree(
     textStyle: TextStyle = LocalTextStyle.current,
     showIndices: Boolean = false,
     showItemCount: Boolean = true,
+    expandSingleChildren: Boolean = false,
     onError: (Throwable) -> Unit = {}
 ) {
     val jsonParser = remember(json) {
@@ -90,7 +94,10 @@ public fun JsonTree(
                     showItemCount = showItemCount,
                     onClick = {
                         coroutineScope.launch {
-                            jsonParser.expandOrCollapseItem(it)
+                            jsonParser.expandOrCollapseItem(
+                                item = it,
+                                expandSingleChildren = expandSingleChildren
+                            )
                         }
                     }
                 )
@@ -201,7 +208,7 @@ private fun JsonTreeList(
                         colors = colors,
                         textStyle = textStyle,
                         indent = if (index == 0 || index == items.lastIndex) {
-                            0.dp
+                            iconSize
                         } else {
                             (item.level * iconSize) + iconSize
                         },

--- a/jsontree/src/test/java/com/sebastianneubauer/jsontree/JsonTreeParserTest.kt
+++ b/jsontree/src/test/java/com/sebastianneubauer/jsontree/JsonTreeParserTest.kt
@@ -319,7 +319,7 @@ internal class JsonTreeParserTest {
                     jsonTreeElement(state = TreeState.EXPANDED, childrenState = TreeState.EXPANDED),
                     array(state = TreeState.EXPANDED, childrenState = TreeState.EXPANDED),
                     nestedArray1(state = TreeState.EXPANDED, childrenState = TreeState.EXPANDED),
-                    objetElement(state = TreeState.EXPANDED),
+                    objectElement(state = TreeState.EXPANDED),
                     stringPrimitive,
                     JsonTreeElement.EndBracket(
                         id = "2-b",
@@ -361,7 +361,7 @@ internal class JsonTreeParserTest {
     }
 
     @Test
-    fun `nested json - expands and collapses correctly`() = runTest {
+    fun `nested json - expandSingleChildren is false - expands and collapses correctly`() = runTest {
         val underTest = underTest(nestedJson, TreeState.COLLAPSED)
         assertEquals(
             Ready(list = listOf(jsonTreeElement())),
@@ -369,7 +369,7 @@ internal class JsonTreeParserTest {
         )
 
         // expand root
-        underTest.expandOrCollapseItem(jsonTreeElement())
+        underTest.expandOrCollapseItem(jsonTreeElement(), expandSingleChildren = false)
 
         assertEquals(
             Ready(
@@ -388,7 +388,7 @@ internal class JsonTreeParserTest {
         )
 
         // expand array
-        underTest.expandOrCollapseItem(array())
+        underTest.expandOrCollapseItem(item = array(), expandSingleChildren = false)
 
         assertEquals(
             Ready(
@@ -415,7 +415,7 @@ internal class JsonTreeParserTest {
         )
 
         // expand nestedArray2
-        underTest.expandOrCollapseItem(nestedArray2())
+        underTest.expandOrCollapseItem(item = nestedArray2(), expandSingleChildren = false)
 
         assertEquals(
             Ready(
@@ -450,7 +450,10 @@ internal class JsonTreeParserTest {
         )
 
         // collapse array
-        underTest.expandOrCollapseItem(array(state = TreeState.EXPANDED, childrenState = TreeState.COLLAPSED))
+        underTest.expandOrCollapseItem(
+            item = array(state = TreeState.EXPANDED, childrenState = TreeState.COLLAPSED),
+            expandSingleChildren = false
+        )
 
         assertEquals(
             Ready(
@@ -469,7 +472,189 @@ internal class JsonTreeParserTest {
         )
 
         // collapse root
-        underTest.expandOrCollapseItem(jsonTreeElement(state = TreeState.EXPANDED, childrenState = TreeState.COLLAPSED))
+        underTest.expandOrCollapseItem(
+            item = jsonTreeElement(state = TreeState.EXPANDED, childrenState = TreeState.COLLAPSED),
+            expandSingleChildren = false
+        )
+
+        assertEquals(
+            Ready(list = listOf(jsonTreeElement())),
+            underTest.state.value
+        )
+    }
+
+    @Test
+    fun `nested json - expandSingleChildren is true - expands and collapses correctly`() = runTest {
+        val underTest = underTest(nestedJson, TreeState.COLLAPSED)
+        assertEquals(
+            Ready(list = listOf(jsonTreeElement())),
+            underTest.state.value
+        )
+
+        // expand root
+        underTest.expandOrCollapseItem(jsonTreeElement(), expandSingleChildren = true)
+
+        assertEquals(
+            Ready(
+                list = listOf(
+                    jsonTreeElement(
+                        state = TreeState.EXPANDED,
+                        childrenState = TreeState.EXPANDED,
+                        grandChildrenState = TreeState.COLLAPSED
+                    ),
+                    array(state = TreeState.EXPANDED),
+                    nestedArray1(),
+                    nestedArray2(),
+                    JsonTreeElement.EndBracket(
+                        id = "7-b",
+                        level = 1,
+                        isLastItem = true,
+                        type = JsonTreeElement.EndBracket.Type.ARRAY
+                    ),
+                    JsonTreeElement.EndBracket(
+                        id = "8-b",
+                        level = 0,
+                        isLastItem = true,
+                        type = JsonTreeElement.EndBracket.Type.OBJECT
+                    ),
+                )
+            ),
+            underTest.state.value
+        )
+
+        // expand nestedArray1, expands nested object as well
+        underTest.expandOrCollapseItem(item = nestedArray1(), expandSingleChildren = true)
+
+        assertEquals(
+            Ready(
+                list = listOf(
+                    jsonTreeElement(
+                        state = TreeState.EXPANDED,
+                        childrenState = TreeState.EXPANDED,
+                        grandChildrenState = TreeState.COLLAPSED
+                    ),
+                    array(state = TreeState.EXPANDED),
+                    nestedArray1(state = TreeState.EXPANDED, childrenState = TreeState.EXPANDED),
+                    objectElement(state = TreeState.EXPANDED),
+                    stringPrimitive,
+                    JsonTreeElement.EndBracket(
+                        id = "2-b",
+                        level = 3,
+                        isLastItem = true,
+                        type = JsonTreeElement.EndBracket.Type.OBJECT
+                    ),
+                    JsonTreeElement.EndBracket(
+                        id = "3-b",
+                        level = 2,
+                        isLastItem = false,
+                        type = JsonTreeElement.EndBracket.Type.ARRAY
+                    ),
+                    nestedArray2(),
+                    JsonTreeElement.EndBracket(
+                        id = "7-b",
+                        level = 1,
+                        isLastItem = true,
+                        type = JsonTreeElement.EndBracket.Type.ARRAY
+                    ),
+                    JsonTreeElement.EndBracket(
+                        id = "8-b",
+                        level = 0,
+                        isLastItem = true,
+                        type = JsonTreeElement.EndBracket.Type.OBJECT
+                    ),
+                )
+            ),
+            underTest.state.value
+        )
+
+        // expand nestedArray2
+        underTest.expandOrCollapseItem(item = nestedArray2(), expandSingleChildren = true)
+
+        assertEquals(
+            Ready(
+                list = listOf(
+                    jsonTreeElement(
+                        state = TreeState.EXPANDED,
+                        childrenState = TreeState.EXPANDED,
+                        grandChildrenState = TreeState.COLLAPSED
+                    ),
+                    array(state = TreeState.EXPANDED),
+                    nestedArray1(state = TreeState.EXPANDED, childrenState = TreeState.EXPANDED),
+                    objectElement(state = TreeState.EXPANDED),
+                    stringPrimitive,
+                    JsonTreeElement.EndBracket(
+                        id = "2-b",
+                        level = 3,
+                        isLastItem = true,
+                        type = JsonTreeElement.EndBracket.Type.OBJECT
+                    ),
+                    JsonTreeElement.EndBracket(
+                        id = "3-b",
+                        level = 2,
+                        isLastItem = false,
+                        type = JsonTreeElement.EndBracket.Type.ARRAY
+                    ),
+                    nestedArray2(state = TreeState.EXPANDED),
+                    numberPrimitive1,
+                    numberPrimitive2,
+                    JsonTreeElement.EndBracket(
+                        id = "6-b",
+                        level = 2,
+                        isLastItem = true,
+                        type = JsonTreeElement.EndBracket.Type.ARRAY
+                    ),
+                    JsonTreeElement.EndBracket(
+                        id = "7-b",
+                        level = 1,
+                        isLastItem = true,
+                        type = JsonTreeElement.EndBracket.Type.ARRAY
+                    ),
+                    JsonTreeElement.EndBracket(
+                        id = "8-b",
+                        level = 0,
+                        isLastItem = true,
+                        type = JsonTreeElement.EndBracket.Type.OBJECT
+                    ),
+                )
+            ),
+            underTest.state.value
+        )
+
+        // collapse array
+        underTest.expandOrCollapseItem(
+            item = array(state = TreeState.EXPANDED),
+            expandSingleChildren = true
+        )
+
+        assertEquals(
+            Ready(
+                list = listOf(
+                    jsonTreeElement(
+                        state = TreeState.EXPANDED,
+                        childrenState = TreeState.EXPANDED,
+                        grandChildrenState = TreeState.COLLAPSED
+                    ),
+                    array(),
+                    JsonTreeElement.EndBracket(
+                        id = "8-b",
+                        level = 0,
+                        isLastItem = true,
+                        type = JsonTreeElement.EndBracket.Type.OBJECT
+                    ),
+                )
+            ),
+            underTest.state.value
+        )
+
+        // collapse root
+        underTest.expandOrCollapseItem(
+            item = jsonTreeElement(
+                state = TreeState.EXPANDED,
+                childrenState = TreeState.COLLAPSED,
+                grandChildrenState = TreeState.COLLAPSED
+            ),
+            expandSingleChildren = true
+        )
 
         assertEquals(
             Ready(list = listOf(jsonTreeElement())),
@@ -504,7 +689,7 @@ internal class JsonTreeParserTest {
         parentType = JsonTreeElement.ParentType.ARRAY
     )
 
-    private fun objetElement(
+    private fun objectElement(
         state: TreeState = TreeState.COLLAPSED,
     ) = JsonTreeElement.Collapsable.Object(
         id = "2",
@@ -529,7 +714,7 @@ internal class JsonTreeParserTest {
         state = state,
         parentType = JsonTreeElement.ParentType.ARRAY,
         children = mapOf(
-            "0" to objetElement(state = childrenState)
+            "0" to objectElement(state = childrenState)
         ),
     )
 
@@ -567,6 +752,7 @@ internal class JsonTreeParserTest {
     private fun jsonTreeElement(
         state: TreeState = TreeState.COLLAPSED,
         childrenState: TreeState = TreeState.COLLAPSED,
+        grandChildrenState: TreeState = childrenState,
     ) = JsonTreeElement.Collapsable.Object(
         id = "8",
         level = 0,
@@ -575,7 +761,7 @@ internal class JsonTreeParserTest {
         key = null,
         parentType = JsonTreeElement.ParentType.NONE,
         children = mapOf(
-            "array" to array(state = childrenState, childrenState = childrenState)
+            "array" to array(state = childrenState, childrenState = grandChildrenState)
         )
     )
 }


### PR DESCRIPTION
- Adds a new parameter to expand every child of arrays and objects if it has no siblings until there are multiple or zero children
- Fixes the indent of the last bracket