### PR TITLE
Fix missing classes of atomicfu plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,9 +4,6 @@ buildscript {
     repositories {
         mavenCentral()
     }
-    dependencies {
-        classpath(libs.atomicfu)
-    }
 }
 
 plugins {

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,7 +33,7 @@ SONATYPE_HOST=S01
 RELEASE_SIGNING_ENABLED=true
 
 GROUP=com.sebastianneubauer.jsontree
-VERSION_NAME=2.4.0
+VERSION_NAME=2.4.1
 
 POM_INCEPTION_YEAR=2023
 POM_URL=https://github.com/snappdevelopment/JsonTree

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ agp = "8.5.2"
 kotlin = "2.0.20"
 publish = "0.29.0"
 api-validator = "0.16.3"
-atomicfu = "0.25.0"
+atomicfu = "0.26.1"
 androidx-activity-compose = "1.9.2"
 kotlinx-serialization-json = "1.7.3"
 kotlinx-coroutines = "1.9.0"
@@ -25,7 +25,7 @@ kotlinx-coroutines-swing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
-atomicfu = { module = "org.jetbrains.kotlinx:atomicfu-gradle-plugin", version.ref = "atomicfu" }
+atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "atomicfu" }
 
 [plugins]
 android-library = { id = "com.android.library", version.ref = "agp" }

--- a/jsontree/build.gradle.kts
+++ b/jsontree/build.gradle.kts
@@ -56,7 +56,9 @@ kotlin {
                 implementation(compose.components.resources)
                 implementation(compose.components.uiToolingPreview)
                 implementation(libs.kotlinx.coroutines.core)
-                implementation (libs.kotlinx.serialization.json)
+                implementation(libs.kotlinx.serialization.json)
+                // needs to be added as a workaround not get atomicfus code stripped
+                implementation(libs.atomicfu)
             }
         }
 

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -93,6 +93,7 @@ kotlin {
         compilations["main"].compilerOptions.options.freeCompilerArgs.add("-Xexport-kdoc")
     }
 
+    jvmToolchain(17)
 }
 
 android {
@@ -106,10 +107,6 @@ android {
     sourceSets["main"].apply {
         manifest.srcFile("src/androidMain/AndroidManifest.xml")
         res.srcDirs("src/androidMain/res")
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
     }
     buildTypes {
         getByName("release")  {


### PR DESCRIPTION
Add atomicfu as a dependency in addition to the plugin. This is a workaround to avoid getting atomicfus code stripped and then crash at runtime, because of missing classes.

closes https://github.com/snappdevelopment/JsonTree/issues/112