### PR TITLE
Fix strings having the wrong color when containing numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ captures/
 .idea/studiobot.xml
 .idea/artifacts
 .idea/runConfigurations.xml
+.idea/AndroidProjectSystem.xml
 
 .kotlin
 

--- a/jsontree/src/commonMain/kotlin/com/sebastianneubauer/jsontree/AnnotatedText.kt
+++ b/jsontree/src/commonMain/kotlin/com/sebastianneubauer/jsontree/AnnotatedText.kt
@@ -88,12 +88,12 @@ internal fun rememberPrimitiveText(
 ): AnnotatedString {
     val valueColor = remember(value) {
         when {
-            value.doubleOrNull != null ||
-                value.intOrNull != null ||
-                value.floatOrNull != null ||
-                value.longOrNull != null -> colors.numberValueColor
-            value.booleanOrNull != null -> colors.booleanValueColor
             value.isString -> colors.stringValueColor
+            value.booleanOrNull != null -> colors.booleanValueColor
+            value.doubleOrNull != null ||
+                    value.intOrNull != null ||
+                    value.floatOrNull != null ||
+                    value.longOrNull != null -> colors.numberValueColor
             else -> colors.nullValueColor
         }
     }

--- a/sample/src/commonMain/kotlin/JsonStrings.kt
+++ b/sample/src/commonMain/kotlin/JsonStrings.kt
@@ -22,7 +22,7 @@ internal val complexJson = """
         			"url": "https://user.com",
         			"description": "bargains independence smell sharing electric extra failures wallpaper freelance higher mathematics disaster directed clicking elder anyone encountered living mattress drill",
         			"verified": true,
-        			"salary": 38775,
+        			"salary": "38775",
                     "newValue": null
         		},
         		{


### PR DESCRIPTION
Values that have been explicitly constructed as strings should be colored as strings. Other values can be interpreted as numbers.